### PR TITLE
Make Request Header section and table headers conditional

### DIFF
--- a/Templates/parameters.def
+++ b/Templates/parameters.def
@@ -6,11 +6,12 @@
 {{~ data.parameters :p}}{{? p.name !== 'body'}}{{? p.in !=='header'}}{{? !p.required }}`[optional] {{? p.originalType}}{{=p.originalType}}{{??}}{{=p.safeType}}{{?}} {{=p.name}}`
 {{? p.description}}<br/>{{=p.description}}{{?}}<br/><br/>{{?}}{{?}}{{?}}{{~}}
 
+{{~ data.headerParameters :p}}
 #### Request Headers
 
 |Header|Type|Required|Description|
 |---|---|---|---|
-{{~ data.headerParameters :p}}|{{=p.name}}|{{? p.originalType}}{{=p.originalType}}{{??}}{{=p.safeType}}{{?}}|{{=p.required }}|{{=p.description}}|
+|{{=p.name}}|{{? p.originalType}}{{=p.originalType}}{{??}}{{=p.safeType}}{{?}}|{{=p.required }}|{{=p.description}}|
 {{~}}
 
 {{~ data.parameters :p}}


### PR DESCRIPTION
Place Request Header section and table headers inside conditional check for presence of data.headerParameters.  This was missed in initial implementation of Request Header table formatting