### PR TITLE
Removed enumerated values from parameters

### DIFF
--- a/Templates/parameters.def
+++ b/Templates/parameters.def
@@ -31,12 +31,4 @@
 
 {{~}}
 
-{{? data.enums && data.enums.length }}
-<h4>Enumerated Values</h4>
-
-|Parameter|Value|
-|---|---|
-{{~ data.enums :e}}|{{=e.name}}|{{=data.utils.toPrimitive(e.value)}}|
-{{~}}
-{{?}}
 {{= data.tags.endSection }}


### PR DESCRIPTION
This is for WI 247297 to remove enumerated values from the parameters section, since it is already in the Definitions section.