### PR TITLE
Added enum descriptions

### DIFF
--- a/Templates/main.dot
+++ b/Templates/main.dot
@@ -50,21 +50,25 @@
 {{ var blocks = data.utils.schemaToArray(origSchema,-1,{trim:true,join:true},data); }}
 {{ for (var block of blocks) {
      for (var p of block.rows) {
-       if (p.schema && p.schema.enum) {
-		if(p.schema['x-enumNames']){
-			var val = 0;
-			for (var e of p.schema.enum) {
-				enums.push({name:p.schema['x-enumNames'][val],value:e});
-				val++;
-			}
-		}else{
-			for (var e of p.schema.enum) {
-				enums.push({name:p.name,value:e});
-			}
-		}		
-       }
-     }
-   }
+    	if (p.schema && p.schema.enum) {
+			if (p.schema['x-enumNames']){
+				var val = 0;
+				for (var e of p.schema.enum) {
+					if (p.schema['x-enumDescriptions']){
+						enums.push({name:p.schema['x-enumNames'][val],value:e,description:p.schema['x-enumDescriptions'][val]});
+					}else{
+						enums.push({name:p.schema['x-enumNames'][val],value:e});
+					}
+					val++;
+				}
+			}else{
+				for (var e of p.schema.enum) {
+					enums.push({name:p.name,value:e});
+				}
+			}		
+    	}
+    }
+}
 }}
 
 {{~ blocks :block}}
@@ -96,10 +100,17 @@
 
 <h4>Enumerated Values</h4>
 
+{{? enums[0].description}}
+|Property|Value|Description|
+|---|---|---|
+{{~ enums :e}}|{{=e.name}}|{{=data.utils.toPrimitive(e.value)}}|{{=e.description}}|
+{{~}}
+{{??}}
 |Property|Value|
 |---|---|
 {{~ enums :e}}|{{=e.name}}|{{=data.utils.toPrimitive(e.value)}}|
 {{~}}
+{{?}}
 
 {{= data.tags.endSection }}
 {{?}}


### PR DESCRIPTION
This PR adds in enum descriptions, when available in the OpenApi JSON via the 'x-enumDescriptions' attribute. The result is that the definitions section will now contain enum descriptions in an additional column when available, and no additional column when unavailable:
![image](https://user-images.githubusercontent.com/19477617/128763123-fc775301-d155-4229-8d42-46c4a1adf045.png)
